### PR TITLE
Keep the GIF properties dictionary alive until we're done

### DIFF
--- a/uiimage-from-animated-gif/UIImage+animatedGIF.m
+++ b/uiimage-from-animated-gif/UIImage+animatedGIF.m
@@ -16,12 +16,12 @@ static int delayCentisecondsForImageAtIndex(CGImageSourceRef const source, size_
     CFDictionaryRef const properties = CGImageSourceCopyPropertiesAtIndex(source, i, NULL);
     if (properties) {
         CFDictionaryRef const gifProperties = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
-        CFRelease(properties);
         if (gifProperties) {
             CFNumberRef const number = CFDictionaryGetValue(gifProperties, kCGImagePropertyGIFDelayTime);
             // Even though the GIF stores the delay as an integer number of centiseconds, ImageIO “helpfully” converts that to seconds for us.
             delayCentiseconds = (int)lrint([fromCF number doubleValue] * 100);
         }
+        CFRelease(properties);
     }
     return delayCentiseconds;
 }


### PR DESCRIPTION
The GIF properties dictionary is, as far as we know, only retained by the image source properties dictionary we got it from. So in order to ensure that the GIF properties dictionary sticks around until we're done with it, we must not release the image source properties dictionary until we no longer need the GIF properties dictionary or any objects obtained from it.

It seems that this is not causing any observable issues, which suggests that there must be something else retaining the image source properties or GIF properties dictionaries (e.g., the image source itself). But that could well change in a future release of OS X.
