### PR TITLE
Fix static analyzer warnings about leaking CGImageSources

### DIFF
--- a/uiimage-from-animated-gif/UIImage+animatedGIF.m
+++ b/uiimage-from-animated-gif/UIImage+animatedGIF.m
@@ -93,7 +93,7 @@ static UIImage *animatedImageWithAnimatedGIFImageSource(CGImageSourceRef const s
     return animation;
 }
 
-static UIImage *animatedImageWithAnimatedGIFReleasingImageSource(CGImageSourceRef source) {
+static UIImage *animatedImageWithAnimatedGIFReleasingImageSource(CGImageSourceRef CF_RELEASES_ARGUMENT source) {
     if (source) {
         UIImage *const image = animatedImageWithAnimatedGIFImageSource(source);
         CFRelease(source);


### PR DESCRIPTION
We aren't leaking them, but the analyzer couldn't tell.
