### PR TITLE
fixed incorrect duration

### DIFF
--- a/uiimage-from-animated-gif/UIImage+animatedGIF.m
+++ b/uiimage-from-animated-gif/UIImage+animatedGIF.m
@@ -17,7 +17,7 @@ static int delayCentisecondsForImageAtIndex(CGImageSourceRef const source, size_
     if (properties) {
         CFDictionaryRef const gifProperties = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
         if (gifProperties) {
-            CFNumberRef const number = CFDictionaryGetValue(gifProperties, kCGImagePropertyGIFDelayTime);
+            CFNumberRef const number = CFDictionaryGetValue(gifProperties, kCGImagePropertyGIFUnclampedDelayTime);
             // Even though the GIF stores the delay as an integer number of centiseconds, ImageIO “helpfully” converts that to seconds for us.
             delayCentiseconds = (int)lrint([fromCF number doubleValue] * 100);
         }


### PR DESCRIPTION
changed kCGImagePropertyGIFDelayTime to kCGImagePropertyGIFUnclampedDelayTime

tested with this gif http://imgur.com/DkkX99X, the correct time was stored inside the kCGImagePropertyGIFUnclampedDelayTime key, kCGImagePropertyGIFDelayTime was too high
